### PR TITLE
Audio Chunking, Hugging Face Summary

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 *.pyo
 *.pyd
 env/
-venv/
+cmd/audio-notes/venv
 *.env
 *.env.*          
 


### PR DESCRIPTION
- used chunking to process text summaries
- Web Socket connection was closing due to <20 timeout window, so needed chunking to approach with a more distributed mindset. This way, we can send over chunks as we make them and then stitch together the audio by appending to a file (for the first chunk, this file is arbitrarily created). 
- At the end, the audio is one cohesive unit

Considerations:
- ElevenLabs token usage; any more ways to optimize this?
- frontend; allow users to select a file from buckets and then this should be good to go